### PR TITLE
clear cache after structure updates

### DIFF
--- a/src/_trep/system.c
+++ b/src/_trep/system.c
@@ -2260,6 +2260,12 @@ static PyObject* L_ddqddqdqdq(System *sys, PyObject *args)
 	return PyFloat_FromDouble(result);
 }
 
+static PyObject* clear_cache(System *sys, PyObject *args)
+{
+    sys->cache = SYSTEM_CACHE_NONE;
+    Py_RETURN_NONE;
+}
+
 static PyObject* update_cache(System *sys, PyObject *args)
 {
     unsigned long flags;
@@ -2324,6 +2330,7 @@ static PyMethodDef methods_list[] = {
     {"_L_ddqddqdq", (PyCFunction)L_ddqddqdq, METH_VARARGS, trep_internal_doc},
     {"_L_ddqddqdqdq", (PyCFunction)L_ddqddqdqdq, METH_VARARGS, trep_internal_doc},
 
+    {"_clear_cache", (PyCFunction)clear_cache, METH_VARARGS, trep_internal_doc},
     {"_update_cache", (PyCFunction)update_cache, METH_VARARGS, trep_internal_doc},
     {NULL}  /* Sentinel */
 };

--- a/src/system.py
+++ b/src/system.py
@@ -834,6 +834,8 @@ class System(_System):
         self._M_dq = np.zeros( (self.nQ, self.nQ, self.nQ), np.double, 'C')
         self._M_dqdq = np.zeros( (self.nQ, self.nQ, self.nQ, self.nQ), np.double, 'C')
 
+        self._clear_cache()
+
         for func in self._structure_changed_funcs:
             func()
 


### PR DESCRIPTION
This PR addresses #19 by clearing the system cache after  calls _structure_changed().  I don't think this should result in any performance hit as the entire cache should probably be cleared after any structure change anyway. 
