### PR TITLE
Update trep c-api to version 3

### DIFF
--- a/src/_trep/c_api.h
+++ b/src/_trep/c_api.h
@@ -1,4 +1,4 @@
-#define TREP_C_API_VERSION 2
+#define TREP_C_API_VERSION 3
 
 
 /* Please increment TREP_C_API_VERSION whenever anything in this file
@@ -82,6 +82,10 @@ enum {
     capi_TapeMeasure_length_dq,
     capi_TapeMeasure_length_dqdq,
     capi_TapeMeasure_length_dqdqdq,
+
+    capi_update_trep_cache,
+    capi_System_state_changed,
+    capi_MidpointVI_solve_DEL,
     
     capi_size
     
@@ -149,17 +153,17 @@ static int import_trep(void)
         return -1;
 #endif
 
+    if(trep_api->version != TREP_C_API_VERSION) {
+        PyErr_Format(PyExc_ImportError, "trep API has unexpected version %d (expected %d)",
+                     trep_api->version, TREP_C_API_VERSION);
+        return -1;
+    }
+
     if(trep_api->size != capi_size) {
         PyErr_Format(PyExc_ImportError, "trep API has unexpected size %d (expected %d)",
                      trep_api->size, capi_size);
         return -1;
         
-    }
-
-    if(trep_api->version != TREP_C_API_VERSION) {
-        PyErr_Format(PyExc_ImportError, "trep API has unexpected version %d (expected %d)",
-                     trep_api->version, TREP_C_API_VERSION);
-        return -1;
     }
 
     trep_API = trep_api->API;
@@ -527,6 +531,26 @@ double TapeMeasure_length_dqdqdq(TapeMeasure *self, Config *q1, Config *q2, Conf
                 ) trep_API[capi_TapeMeasure_length_dqdqdq])(self, q1, q2, q3);
 }
 
+ATTRIBUTE_UNUSED
+void System_state_changed(System *sys)
+{
+    return (*(void (*)(System*)
+                ) trep_API[capi_System_state_changed])(sys);
+}
+
+ATTRIBUTE_UNUSED 
+int update_trep_cache(System *sys, unsigned long flags)
+{
+    return (*(int (*)(System*, unsigned long)
+                ) trep_API[capi_update_trep_cache])(sys, flags);
+}
+
+ATTRIBUTE_UNUSED 
+int MidpointVI_solve_DEL(MidpointVI *mvi, int max_iterations)
+{
+    return (*(int (*)(MidpointVI*, int)
+                ) trep_API[capi_MidpointVI_solve_DEL])(mvi, max_iterations);
+}
 
 #endif  /* TREP_MODULE not defined. */
 
@@ -620,6 +644,10 @@ static PyObject* export_trep(void)
     trep_API[capi_TapeMeasure_length_dq] = (void*)TapeMeasure_length_dq;
     trep_API[capi_TapeMeasure_length_dqdq] = (void*)TapeMeasure_length_dqdq;
     trep_API[capi_TapeMeasure_length_dqdqdq] = (void*)TapeMeasure_length_dqdqdq;
+
+    trep_API[capi_System_state_changed] = (void*)System_state_changed;
+    trep_API[capi_update_trep_cache] = (void*)update_trep_cache;
+    trep_API[capi_MidpointVI_solve_DEL] = (void*)MidpointVI_solve_DEL;
 
     trep_API_def.version = TREP_C_API_VERSION;
     trep_API_def.size = capi_size;

--- a/src/_trep/midpointvi.c
+++ b/src/_trep/midpointvi.c
@@ -688,7 +688,7 @@ static int DEL_solved(MidpointVI *mvi)
     return 1;  
 }
 
-static int MidpointVI_solve_DEL(MidpointVI *mvi, int max_iterations)
+int MidpointVI_solve_DEL(MidpointVI *mvi, int max_iterations)
 {
     int iterations;
     int row;

--- a/src/_trep/system.c
+++ b/src/_trep/system.c
@@ -893,7 +893,7 @@ static void calc_f(System *sys)
 	System_DYN_CONFIG(sys, i1)->ddq = F(i1);
 }    
 
-static int calc_dynamics(System *sys)
+int calc_dynamics(System *sys)
 {
     if(sys->cache & SYSTEM_CACHE_DYNAMICS)
 	return 0;
@@ -1281,7 +1281,7 @@ static void calc_f_du(System *sys)
     }
 }    
 
-static int calc_dynamics_deriv1(System *sys)
+int calc_dynamics_deriv1(System *sys)
 {
     if(sys->cache & SYSTEM_CACHE_DYNAMICS_DERIV1)
 	return 0;
@@ -2028,6 +2028,53 @@ int calc_dynamics_deriv2(System *sys)
     return 0;
 }
 
+int update_trep_cache(System *sys, unsigned long flags)
+{
+    if(flags & SYSTEM_CACHE_LG)
+        build_lg_cache(sys);
+    if(flags & SYSTEM_CACHE_G)
+        build_g_cache(sys);
+    if(flags & SYSTEM_CACHE_G_DQ)
+        build_g_dq_cache(sys);
+    if(flags & SYSTEM_CACHE_G_DQDQ)
+        build_g_dqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_G_DQDQDQ)
+        build_g_dqdqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_G_DQDQDQDQ)
+        build_g_dqdqdqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_G_INV)
+        build_g_inv_cache(sys);
+    if(flags & SYSTEM_CACHE_G_INV_DQ)
+        build_g_inv_dq_cache(sys);
+    if(flags & SYSTEM_CACHE_G_INV_DQDQ)
+        build_g_inv_dqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_VB)
+        build_vb_cache(sys);
+    if(flags & SYSTEM_CACHE_VB_DQ)
+        build_vb_dq_cache(sys);
+    if(flags & SYSTEM_CACHE_VB_DQDQ)
+        build_vb_dqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_VB_DQDQDQ)
+        build_vb_dqdqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_VB_DDQ)
+        build_vb_ddq_cache(sys);
+    if(flags & SYSTEM_CACHE_VB_DDQDQ)
+        build_vb_ddqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_VB_DDQDQDQ)
+        build_vb_ddqdqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_VB_DDQDQDQDQ)
+        build_vb_ddqdqdqdq_cache(sys);
+    if(flags & SYSTEM_CACHE_DYNAMICS)
+        calc_dynamics(sys);
+    if(flags & SYSTEM_CACHE_DYNAMICS_DERIV1)
+        calc_dynamics_deriv1(sys);
+    if(flags & SYSTEM_CACHE_DYNAMICS_DERIV2)
+        calc_dynamics_deriv2(sys);
+    if(PyErr_Occurred())
+	    return -1;
+    return 0;
+}
+
 
 /***********************************************************************
  * Python API
@@ -2266,46 +2313,9 @@ static PyObject* update_cache(System *sys, PyObject *args)
     if(!PyArg_ParseTuple(args, "k", &flags))
         return NULL;
     CALLGRIND_START_INSTRUMENTATION;
-    if(flags & SYSTEM_CACHE_LG)
-        build_lg_cache(sys);
-    if(flags & SYSTEM_CACHE_G)
-        build_g_cache(sys);
-    if(flags & SYSTEM_CACHE_G_DQ)
-        build_g_dq_cache(sys);
-    if(flags & SYSTEM_CACHE_G_DQDQ)
-        build_g_dqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_G_DQDQDQ)
-        build_g_dqdqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_G_DQDQDQDQ)
-        build_g_dqdqdqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_G_INV)
-        build_g_inv_cache(sys);
-    if(flags & SYSTEM_CACHE_G_INV_DQ)
-        build_g_inv_dq_cache(sys);
-    if(flags & SYSTEM_CACHE_G_INV_DQDQ)
-        build_g_inv_dqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_VB)
-        build_vb_cache(sys);
-    if(flags & SYSTEM_CACHE_VB_DQ)
-        build_vb_dq_cache(sys);
-    if(flags & SYSTEM_CACHE_VB_DQDQ)
-        build_vb_dqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_VB_DQDQDQ)
-        build_vb_dqdqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_VB_DDQ)
-        build_vb_ddq_cache(sys);
-    if(flags & SYSTEM_CACHE_VB_DDQDQ)
-        build_vb_ddqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_VB_DDQDQDQ)
-        build_vb_ddqdqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_VB_DDQDQDQDQ)
-        build_vb_ddqdqdqdq_cache(sys);
-    if(flags & SYSTEM_CACHE_DYNAMICS)
-        calc_dynamics(sys);
-    if(flags & SYSTEM_CACHE_DYNAMICS_DERIV1)
-        calc_dynamics_deriv1(sys);
-    if(flags & SYSTEM_CACHE_DYNAMICS_DERIV2)
-        calc_dynamics_deriv2(sys);
+    update_trep_cache(sys, flags);
+    if(PyErr_Occurred())
+	    return NULL;
     CALLGRIND_STOP_INSTRUMENTATION;
     Py_RETURN_NONE;
 }

--- a/src/_trep/trep.h
+++ b/src/_trep/trep.h
@@ -695,6 +695,7 @@ struct TapeMeasure_s {
     PyArrayObject *seg_table;
 };
 
+
 #define TapeMeasure_USES_CONFIG(self, q) ( ((int*)IDX1(self->seg_table, q->index))[0] != -1)
 
 
@@ -765,6 +766,15 @@ PYEXPORT double TapeMeasure_length(TapeMeasure *self);
 PYEXPORT double TapeMeasure_length_dq(TapeMeasure *self, Config *q1);
 PYEXPORT double TapeMeasure_length_dqdq(TapeMeasure *self, Config *q1, Config *q2);
 PYEXPORT double TapeMeasure_length_dqdqdq(TapeMeasure *self, Config *q1, Config *q2, Config *q3);
+
+
+/*******************************************************************************
+ * Trep Cache/MVI Update Functions
+ */
+
+PYEXPORT void System_state_changed(System *system);
+PYEXPORT int update_trep_cache(System *sys, unsigned long flags);
+PYEXPORT int MidpointVI_solve_DEL(MidpointVI *mvi, int max_iterations);
 
 
 /*******************************************************************************
@@ -957,7 +967,6 @@ void build_vb_ddqdqdqdq_cache(System *system);
 
 
 /* Updates caching/performance values in the system. */
-void System_state_changed(System *system);
 double System_total_energy(System *system);
 double System_L(System *system);
 double System_L_dq(System *system, Config *q1);


### PR DESCRIPTION
Allows for public access to System_state_changed, MidpointVI_solve_DEL, and update_trep_cache functions.  A new release should accompany this PR once merged.