### PR TITLE
Updates to ROS module

### DIFF
--- a/src/ros/ros_mvi.py
+++ b/src/ros/ros_mvi.py
@@ -8,35 +8,19 @@ class ROSMidpointVI(MidpointVI):
 
         self.dt = timestep
         self.rate = rospy.Rate(1/self.dt)
-        self.pub = rospy.Publisher('joint_states', JointState, queue_size=10)
-        self.joint_msg = JointState()
-
-        if [config.name[-3:] for config in system.configs[:6]] == ['-TX', '-TY', '-TZ', '-RX', '-RY', '-RZ']:
-            self.floating = True
-            self.br = tf.TransformBroadcaster()
-            for config in system.configs[6:]:
-                self.joint_msg.name.append(config.name)
-        else:
-            self.floating = False
-            for config in system.configs:
-                self.joint_msg.name.append(config.name)
+        self.br = tf.TransformBroadcaster()
 
     def step(self, u1=tuple(), k2=tuple(), max_iterations=200, q2_hint=None, lambda1_hint=None):
         steps = super(ROSMidpointVI, self).step(self.t2+self.dt, u1=u1, k2=k2, max_iterations=max_iterations, q2_hint=q2_hint, lambda1_hint=lambda1_hint)
 
-        self.joint_msg.header.stamp = rospy.Time.now()
-
-        if self.floating is True:
-            self.joint_msg.position = self.q2[6:]
-            self.br.sendTransform(self.system.frames[6].g()[:3,3],
-                                 tf.transformations.quaternion_from_matrix(self.system.frames[6].g()),
-                                 self.joint_msg.header.stamp,
-                                 self.system.frames[6].name,
+        self.stamp = rospy.Time.now()
+        for frame in self.system.frames:
+            self.br.sendTransform(frame.g()[:3,3],
+                                 tf.transformations.quaternion_from_matrix(frame.g()),
+                                 self.stamp,
+                                 frame.name,
                                  "world")
-        else:
-            self.joint_msg.position = self.q2
 
-        self.pub.publish(self.joint_msg)
         return steps
 
     def sleep(self):

--- a/src/ros/urdf_parser.py
+++ b/src/ros/urdf_parser.py
@@ -8,10 +8,10 @@ def transform(xyz, rpy):
     r = rpy[0];
     p = rpy[1];
     y = rpy[2];
-    
-    return np.array([[cos(y)*cos(p), cos(y)*sin(p)*sin(r)-sin(y)*cos(r), cos(y)*sin(p)*cos(r)+sin(y)*sin(r)],
-            [sin(y)*cos(p), sin(y)*sin(p)*sin(r)+cos(y)*cos(r), sin(y)*sin(p)*cos(r)-cos(y)*sin(r)],
-            [-sin(p), cos(p)*sin(r), cos(p)*cos(r)],
+   
+    return np.array([[cos(y)*cos(p), cos(y)*sin(p)*sin(r)+sin(y)*cos(r), -cos(y)*sin(p)*cos(r)+sin(y)*sin(r)],
+            [-sin(y)*cos(p), -sin(y)*sin(p)*sin(r)+cos(y)*cos(r), sin(y)*sin(p)*cos(r)+cos(y)*sin(r)],
+            [sin(p), -cos(p)*sin(r), cos(p)*cos(r)],
             xyz])
 
 def rotate(axis):


### PR DESCRIPTION
All trep frames are now published to the /tf topic for use in Rviz.  Now, the robot state publisher is no longer needed to provide the transforms.  Also includes a sign fix in urdf_parser.